### PR TITLE
Set up Docker Compose with basic service scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/calculator/Dockerfile
+++ b/calculator/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+EXPOSE 8001
+CMD ["python", "calculator.py"]

--- a/calculator/calculator.py
+++ b/calculator/calculator.py
@@ -1,0 +1,17 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"Calculator Service")
+
+
+def run():
+    server = HTTPServer(("0.0.0.0", 8001), Handler)
+    print("Calculator service running on port 8001")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.9"
+
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+  price_loader:
+    build: ./price_loader
+    ports:
+      - "8000:8000"
+    volumes:
+      - shared_data:/app/shared
+    depends_on:
+      - redis
+
+  calculator:
+    build: ./calculator
+    ports:
+      - "8001:8001"
+    volumes:
+      - shared_data:/app/shared
+    depends_on:
+      - redis
+
+  jump_graph:
+    build: ./jump_graph
+    ports:
+      - "8002:8002"
+    volumes:
+      - shared_data:/app/shared
+    depends_on:
+      - redis
+
+  ui:
+    build: ./ui
+    ports:
+      - "8501:8501"
+    depends_on:
+      - price_loader
+      - calculator
+      - jump_graph
+
+volumes:
+  redis_data:
+  shared_data:

--- a/jump_graph/Dockerfile
+++ b/jump_graph/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+EXPOSE 8002
+CMD ["python", "build_graph.py"]

--- a/jump_graph/build_graph.py
+++ b/jump_graph/build_graph.py
@@ -1,0 +1,17 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"Jump Graph Service")
+
+
+def run():
+    server = HTTPServer(("0.0.0.0", 8002), Handler)
+    print("Jump Graph service running on port 8002")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/price_loader/Dockerfile
+++ b/price_loader/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+EXPOSE 8000
+CMD ["python", "price_loader.py"]

--- a/price_loader/price_loader.py
+++ b/price_loader/price_loader.py
@@ -1,0 +1,17 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"Price Loader Service")
+
+
+def run():
+    server = HTTPServer(("0.0.0.0", 8000), Handler)
+    print("Price Loader service running on port 8000")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+EXPOSE 8501
+CMD ["python", "app.py"]

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,0 +1,18 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"UI Service")
+
+
+def run():
+    port = 8501
+    server = HTTPServer(("0.0.0.0", port), Handler)
+    print(f"UI service running on port {port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add docker-compose configuration for redis, microservices, and UI with shared volumes
- scaffold Python-based placeholders for price loading, calculation, jump graph, and UI services
- include Dockerfiles and gitignore for initial development setup

## Testing
- `python -m py_compile price_loader/price_loader.py calculator/calculator.py jump_graph/build_graph.py ui/app.py`
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_b_68912126ccdc832d96517b3bdd403f34