### PR TITLE
Add station fetcher and include item names in opportunities

### DIFF
--- a/calculator/calculator.py
+++ b/calculator/calculator.py
@@ -12,6 +12,7 @@ Each stored opportunity contains:
 * ``from`` – source trade hub name
 * ``to`` – destination trade hub name
 * ``item_id`` – type identifier
+* ``item_name`` – human-readable item name
 * ``amount`` – number of units that can be traded
 * ``full_volume`` – total volume in m³
 * ``full_price`` – total sale price at the destination
@@ -157,6 +158,7 @@ def calculate_item_opportunities(item_id: int, item: dict) -> list[dict]:
             "from": name_a,
             "to": name_b,
             "item_id": item_id,
+            "item_name": item.get("name"),
             "amount": amount,
             "full_volume": full_volume,
             "full_price": full_price,

--- a/shared/load_stations.py
+++ b/shared/load_stations.py
@@ -1,0 +1,37 @@
+import json
+import urllib.request
+from pathlib import Path
+
+ESI_BASE = "https://esi.evetech.net/latest"
+USER_AGENT = (
+    "EveEasyTrade/0.1 (+https://github.com/your/repository)"
+)
+
+def get_json(url: str):
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req) as resp:  # nosec B310 - trusted source
+        return json.loads(resp.read().decode())
+
+def fetch_all_stations():
+    station_ids = get_json(f"{ESI_BASE}/universe/stations/")
+    stations = []
+    for station_id in station_ids:
+        info = get_json(f"{ESI_BASE}/universe/stations/{station_id}/")
+        name = info.get("name")
+        stations.append({"id": station_id, "name": name})
+        print(f"Fetched station {station_id}: {name}")
+    return stations
+
+def save_stations(stations, out_file: Path) -> None:
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    with out_file.open("w") as f:
+        json.dump(stations, f, indent=2)
+
+def main() -> None:
+    stations = fetch_all_stations()
+    out_file = Path(__file__).parent / "static_data" / "stations.json"
+    save_stations(stations, out_file)
+    print(f"Saved {len(stations)} stations to {out_file}")
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()


### PR DESCRIPTION
## Summary
- gather all EVE stations via ESI and save to `stations.json`
- enrich opportunity calculations with item names derived from static data

## Testing
- `python -m py_compile calculator/calculator.py shared/load_stations.py`


------
https://chatgpt.com/codex/tasks/task_b_68924d53c69c832d9c943d97445d378d